### PR TITLE
Fix secrets scripts for Windows, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ A running instance of MongoDB is required this project.
 ### Node
 1. Clone this project to your computer
 2. Navigate to this project in terminal and enter `npm install`
-3. Rename `.env.local.example` to `.env.local` and fill it out with the dev config
+3. Run `npm run secrets` to sync secrets to `.env.local`
+  - **OR** Rename `.env.local.example` to `.env.local` and fill it out with the dev config
+  - **NOTE**: Windows users will need to run `npm run secrets:login` and `npm run secrets:sync` instead of the above command
 
 ### Updating Env Vars
 - For dev, update `.env.local`

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "type-check": "tsc --pretty --noEmit",
     "format": "prettier --write **/*.{js,jsx,ts,tsx,json,css,scss}",
     "lint": "eslint --fix --ext ts --ext tsx --ext js --ext jsx .",
-    "secrets": "npm run secrets:logout && npm run secrets:login 'npm run secrets:sync'",
-    "secrets:logout": "(bw logout || true)",
-    "secrets:login": "cross-env-shell BW_SESSION=`bw login product@bitsofgood.org --raw`",
+    "secrets": "npm run secrets:logout && cross-env-shell BW_SESSION=`bw login product@bitsofgood.org --raw` \"npm run secrets:sync\"",
+    "secrets:logout": "(bw logout || exit 0)",
+    "secrets:login": "bw login product@bitsofgood.org",
     "secrets:sync": "bw sync && bw get item npp/.env.local | fx .notes > '.env.local'"
   },
   "dependencies": {


### PR DESCRIPTION
Windows users have to run `npm run secrets:login` and `npm run secrets:sync` scripts individually