### PR TITLE
120-Update Sessions

### DIFF
--- a/server/mongodb/actions/UserManager.ts
+++ b/server/mongodb/actions/UserManager.ts
@@ -2,7 +2,6 @@ import { connectToDB, EntityDoc } from "../index";
 import UserDocument from "../UserDocument";
 import { ObjectId } from "mongodb";
 import { Profile } from "&server/models/Profile";
-import { DocumentQuery } from "mongoose";
 
 export async function getUserById(id: ObjectId) {
   await connectToDB();

--- a/server/mongodb/actions/UserManager.ts
+++ b/server/mongodb/actions/UserManager.ts
@@ -2,6 +2,7 @@ import { connectToDB, EntityDoc } from "../index";
 import UserDocument from "../UserDocument";
 import { ObjectId } from "mongodb";
 import { Profile } from "&server/models/Profile";
+import { DocumentQuery } from "mongoose";
 
 export async function getUserById(id: ObjectId) {
   await connectToDB();
@@ -9,10 +10,10 @@ export async function getUserById(id: ObjectId) {
   return UserDocument.findById(id);
 }
 
-export async function getUserByEmail(email: string) {
+export async function getUserByEmail(email: string, lean = false) {
   await connectToDB();
 
-  return UserDocument.findOne({ email: email });
+  return UserDocument.findOne({ email: email }, {}, { lean });
 }
 
 export async function upsertUserByProviderProfile(

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -3,7 +3,10 @@ import { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
 import { SessionUser } from "&server/models/SessionUser";
 import * as Authentication from "&server/utils/Authentication";
 import BitsAuth0Provider from "&server/auth/BitsAuth0Provider";
-import { upsertUserByProviderProfile } from "&server/mongodb/actions/UserManager";
+import {
+  getUserByEmail,
+  upsertUserByProviderProfile,
+} from "&server/mongodb/actions/UserManager";
 
 export type AuthSession = {
   user: SessionUser;
@@ -11,40 +14,47 @@ export type AuthSession = {
   accessToken?: string;
 };
 
+export type JwtPayload = SessionUser & {
+  iat: number;
+  exp: number;
+};
+
+const JWT_MAX_AGE = 30 * 24 * 60 * 60;
+
 const options = {
   debug: !!parseInt(process.env.DEBUG_AUTH ?? "0"),
   providers: [BitsAuth0Provider],
   session: {
     jwt: true,
+    maxAge: JWT_MAX_AGE,
   },
   events: {},
   callbacks: {
     // This is called when generating the jwt. It is also called after deserializing a JWT
     jwt: (async (
-      token: SessionUser | { name: string; email: string; picture: string },
+      token: JwtPayload | { name: string; email: string; picture: string },
       user: unknown,
       account: unknown,
       auth0Profile: any
     ): Promise<SessionUser> => {
       if (!auth0Profile) {
-        // the token has already been generated; assume it is the SessionUser
-        return token as SessionUser;
+        token = token as JwtPayload;
+        if (isTokenExpired(token)) {
+          return refreshToken(token);
+        }
+
+        // the toke has already been generated; assume it is the SessionUser
+        return token;
       }
       // in case we decide to switch back; can be made more efficient, keep the function in the provider
       const profile = BitsAuth0Provider.profile(auth0Profile);
       const dbUser = await upsertUserByProviderProfile(profile);
-      return {
-        ...profile,
-        id: dbUser._id.toString(),
-        isAdmin: profile.roles.includes(Authentication.ADMIN_ROLE),
-        // for users created before the organizationVerified field was added
-        organizationVerified: !!dbUser.organizationVerified,
-      };
+      return generateJwtPayloadFromDbUser(dbUser);
     }) as any,
     // the default session does not include our custom UserSessions fields, add them here
     session: (async (
       defaultSessionPayload: { expiresAt: string; accessToken?: string },
-      jwtPayload: SessionUser
+      jwtPayload: JwtPayload
     ): Promise<AuthSession> => {
       return Promise.resolve({
         ...defaultSessionPayload,
@@ -53,6 +63,31 @@ const options = {
     }) as any,
   },
 };
+
+function isTokenExpired(jwtToken: JwtPayload): boolean {
+  return !jwtToken.organizationVerified;
+}
+
+async function refreshToken(jwtToken: JwtPayload): Promise<SessionUser> {
+  const user = await getUserByEmail(jwtToken.email);
+  return generateJwtPayloadFromDbUser(user);
+}
+
+function generateJwtPayloadFromDbUser(
+  dbUser: Record<string, any>
+): SessionUser {
+  return {
+    id: dbUser._id.toString(),
+    name: dbUser.name,
+    email: dbUser.email,
+    image: dbUser.image,
+    familyName: dbUser.familyName,
+    roles: dbUser.roles,
+    isAdmin: dbUser.roles.includes(Authentication.ADMIN_ROLE),
+    // for users created before the organizationVerified field was added
+    organizationVerified: !!dbUser.organizationVerified,
+  };
+}
 
 const handler: NextApiHandler = (req: NextApiRequest, res: NextApiResponse) =>
   NextAuth(req, res, options);


### PR DESCRIPTION
Whenever a session is fetched, it will now update the session with the latest information if the user's organization hasn't been verified. 

Why only check to see if this field has been updated? All of the other fields are relatively immutable with an exception to roles. Since roles would need to be fetched from Auth0, we probably don't want to hit that endpoint when updating JWT's....only when initially signing in for performance.

Fixes #120 

Tested locally