### PR TITLE
Improve type consistency (#1)

### DIFF
--- a/server/models/Meeting.ts
+++ b/server/models/Meeting.ts
@@ -1,8 +1,8 @@
 import { DateTime } from "luxon";
+import { Availability } from "&server/models/Availability";
 
-export interface Meeting {
+export interface MeetingCore {
   id?: string;
-  availability: string;
   nonprofit: string;
   application: string;
   cancelled?: boolean;
@@ -10,4 +10,12 @@ export interface Meeting {
   updatedAt?: DateTime;
   meetingId?: number;
   meetingLink?: string;
+}
+
+export interface Meeting extends MeetingCore {
+  availability: string;
+}
+
+export interface MeetingWithAvailability extends MeetingCore {
+  availability: Availability;
 }

--- a/server/mongodb/ToObjectId.ts
+++ b/server/mongodb/ToObjectId.ts
@@ -1,0 +1,5 @@
+import { Types } from "mongoose";
+
+export function toObjectId(id: string): Types.ObjectId {
+  return Types.ObjectId(id);
+}

--- a/server/mongodb/actions/MeetingManager.ts
+++ b/server/mongodb/actions/MeetingManager.ts
@@ -2,12 +2,18 @@ import { Types } from "mongoose";
 import { connectToDB } from "../index";
 import MeetingDocument from "../MeetingDocument";
 import {
-  updateAvailability,
+  docToAvailability,
   getAvailabilityById,
+  updateAvailability,
 } from "&server/mongodb/actions/AvailabilityManager";
-import { Meeting } from "&server/models/Meeting";
+import {
+  Meeting,
+  MeetingCore,
+  MeetingWithAvailability,
+} from "&server/models/Meeting";
 import { updateApplicationStage } from "&server/mongodb/actions/ApplicationManager";
 import { StageType } from "&server/models/StageType";
+import { DateTime } from "luxon";
 
 export async function addMeeting(meeting: Meeting) {
   await connectToDB();
@@ -36,27 +42,33 @@ export async function addMeeting(meeting: Meeting) {
     StageType.SCHEDULED
   );
 
-  return createdMeeting;
+  return docToMeeting(createdMeeting);
 }
 
 // set limit?
-export async function getMeetings() {
+export async function getMeetings(): Promise<Meeting[]> {
   await connectToDB();
 
-  return MeetingDocument.find().sort({ startDateTime: -1 });
+  return (await MeetingDocument.find().sort({ startDateTime: -1 }).lean()).map(
+    docToMeeting
+  );
 }
 
-export async function getMeetingById(id: Types.ObjectId) {
+export async function getMeetingById(
+  id: Types.ObjectId
+): Promise<Meeting | null> {
   await connectToDB();
-
-  return MeetingDocument.findById(id);
+  const meeting = await MeetingDocument.findById(id).lean();
+  return meeting != null ? docToMeeting(meeting) : null;
 }
 
-export async function getMeetingByApplicationId(id: string) {
+export async function getMeetingByApplicationId(
+  id: Types.ObjectId
+): Promise<MeetingWithAvailability> {
   await connectToDB();
 
   const meeting = await MeetingDocument.findOne({
-    application: Types.ObjectId(id),
+    application: id,
   })
     .sort({
       createdAt: -1,
@@ -68,10 +80,10 @@ export async function getMeetingByApplicationId(id: string) {
     throw new Error("Application does not have a meeting!");
   }
 
-  return meeting;
+  return docToMeetingWithAvailability(meeting);
 }
 
-export async function cancelMeeting(id: Types.ObjectId) {
+export async function cancelMeeting(id: Types.ObjectId): Promise<Meeting> {
   await connectToDB();
 
   const meeting = await MeetingDocument.findByIdAndUpdate(
@@ -93,7 +105,36 @@ export async function cancelMeeting(id: Types.ObjectId) {
     isBooked: false,
   });
 
-  return meeting;
+  return docToMeeting(meeting) as Meeting;
+}
+
+export function docToMeeting(object: { [key: string]: any }): Meeting {
+  return {
+    ...docToMeetingCore(object),
+    availability: object.availability as string,
+  };
+}
+
+export function docToMeetingWithAvailability(object: {
+  [key: string]: any;
+}): MeetingWithAvailability {
+  return {
+    ...docToMeetingCore(object),
+    availability: docToAvailability(object.availability),
+  };
+}
+
+export function docToMeetingCore(object: { [key: string]: any }): MeetingCore {
+  return {
+    id: object._id?.toString(),
+    nonprofit: object.nonprofit?.toString(),
+    application: object.application?.toString(),
+    cancelled: object.cancelled,
+    createdAt: DateTime.fromISO(object.createdAt.toISOString()),
+    updatedAt: DateTime.fromISO(object.updatedAt.toISOString()),
+    meetingId: -1,
+    meetingLink: "",
+  } as MeetingCore;
 }
 
 export async function genConferenceLinks(meeting: Meeting) {

--- a/src/actions/AvailabilityActions.ts
+++ b/src/actions/AvailabilityActions.ts
@@ -3,6 +3,7 @@ import { HttpMethod } from "&server/models/HttpMethod";
 import urls from "&utils/urls";
 import { DateTime } from "luxon";
 import { Availability } from "&server/models/Availability";
+
 const availabilityRoute = urls.api.availability;
 
 export async function getAvailabilityById(
@@ -65,12 +66,10 @@ export function availabilityFromJsonResponse(object: {
   [key: string]: any;
 }): Availability {
   return {
-    id: object._id?.toString(),
-    interviewer: object.interviewer?.toString(),
+    ...object,
     startDatetime: DateTime.fromISO(
       new Date(object.startDatetime).toISOString()
     ),
     endDatetime: DateTime.fromISO(new Date(object.endDatetime).toISOString()),
-    isBooked: object.isBooked,
-  };
+  } as Availability;
 }

--- a/src/actions/MeetingActions.ts
+++ b/src/actions/MeetingActions.ts
@@ -2,9 +2,14 @@ import { Types } from "mongoose";
 import { callInternalAPI } from "&server/utils/ActionUtils";
 import { HttpMethod } from "&server/models/HttpMethod";
 import urls from "&utils/urls";
-import { Meeting } from "&server/models/Meeting";
+import {
+  MeetingCore,
+  Meeting,
+  MeetingWithAvailability,
+} from "&server/models/Meeting";
 import { DateTime } from "luxon";
 import { availabilityFromJsonResponse } from "&actions/AvailabilityActions";
+import { object } from "prop-types";
 
 const meetingRoute = urls.api.meeting;
 
@@ -18,12 +23,12 @@ export async function getMeetingById(objectId: string): Promise<Meeting> {
 
 export async function getMeetingByApplicationId(
   objectId: string
-): Promise<Meeting> {
+): Promise<MeetingWithAvailability> {
   const response: Record<string, any> = await callInternalAPI(
     meetingRoute + `?applicationId=${objectId}`,
     HttpMethod.GET
   );
-  return meetingFromJsonResponse(response);
+  return meetingWithAvailabilityFromJsonResponse(response);
 }
 
 export async function getMeetings(): Promise<Meeting[]> {
@@ -53,18 +58,26 @@ export function meetingFromJsonResponse(object: {
   [key: string]: any;
 }): Meeting {
   return {
-    id: object._id?.toString(),
-    availability:
-      typeof object.availability === "string" ||
-      object.availability instanceof Types.ObjectId
-        ? object.availability.toString()
-        : availabilityFromJsonResponse(object.availability),
-    nonprofit: object.nonprofit?.toString(),
-    application: object.application?.toString(),
-    cancelled: object.cancelled,
+    ...meetingCoreFromJsonResponse(object),
+    availability: object.availability as string,
+  };
+}
+
+export function meetingWithAvailabilityFromJsonResponse(object: {
+  [key: string]: any;
+}): MeetingWithAvailability {
+  return {
+    ...meetingCoreFromJsonResponse(object),
+    availability: availabilityFromJsonResponse(object.availability),
+  };
+}
+
+export function meetingCoreFromJsonResponse(object: {
+  [key: string]: any;
+}): MeetingCore {
+  return {
+    ...object,
     createdAt: DateTime.fromISO(new Date(object.createdAt).toISOString()),
     updatedAt: DateTime.fromISO(new Date(object.updatedAt).toISOString()),
-    meetingId: -1,
-    meetingLink: "",
-  };
+  } as MeetingCore;
 }

--- a/src/pages/api/meeting.ts
+++ b/src/pages/api/meeting.ts
@@ -29,9 +29,7 @@ const handler = generateMethodRoute(
         );
         return validateUserHasAccessToMeeting(
           user,
-          await MeetingManager.getMeetingByApplicationId(
-            req.query.applicationId as string
-          )
+          await MeetingManager.getMeetingByApplicationId(objectId)
         );
       } else {
         Authentication.ensureAdmin(user);

--- a/src/screens/App/Scheduled/index.tsx
+++ b/src/screens/App/Scheduled/index.tsx
@@ -3,15 +3,12 @@ import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import { DateTime } from "luxon";
 import Swal from "sweetalert2";
-
 // Iconography
 import Clock from "&icons/Clock";
 import LocationPin from "&icons/LocationPin";
-
 // Components
 import Button from "&components/Button";
 import Statusbar from "&components/Statusbar";
-
 // Utils
 import urls from "&utils/urls";
 import { Application } from "&server/models/Application";
@@ -21,12 +18,14 @@ import { useSession } from "&utils/auth-utils";
 import { Meeting } from "&server/models/Meeting";
 import { Availability } from "&server/models/Availability";
 import {
-  meetingFromJsonResponse,
   cancelMeeting,
+  getMeetingByApplicationId,
+  getMeetings,
+  meetingFromJsonResponse,
 } from "&actions/MeetingActions";
-
 // Styling
 import classes from "./Scheduled.module.scss";
+import { toObjectId } from "&server/mongodb/ToObjectId";
 
 interface PropTypes {
   application: Application;
@@ -205,10 +204,9 @@ export const getStaticProps: GetStaticProps = async (context) => {
         revalidate: 1,
       };
     } else {
-      const meeting = await MeetingManager.getMeetingByApplicationId(id);
-      const meetingJson = meetingFromJsonResponse(meeting) as Meeting & {
-        availability: Availability;
-      };
+      const meeting = await MeetingManager.getMeetingByApplicationId(
+        toObjectId(id as string)
+      );
 
       return {
         props: {
@@ -218,14 +216,14 @@ export const getStaticProps: GetStaticProps = async (context) => {
             updatedAt: appJson.updatedAt?.toISO(),
           },
           meeting: {
-            ...meetingJson,
+            ...meeting,
             availability: {
-              ...((meetingJson.availability as unknown) as Meeting),
-              startDatetime: meetingJson.availability.startDatetime?.toISO(),
-              endDatetime: meetingJson.availability.endDatetime?.toISO(),
+              ...((meeting.availability as unknown) as Meeting),
+              startDatetime: meeting.availability.startDatetime?.toISO(),
+              endDatetime: meeting.availability.endDatetime?.toISO(),
             },
-            createdAt: meetingJson.createdAt?.toISO(),
-            updatedAt: meetingJson.updatedAt?.toISO(),
+            createdAt: meeting.createdAt?.toISO(),
+            updatedAt: meeting.updatedAt?.toISO(),
           },
         },
         revalidate: 60,


### PR DESCRIPTION
Improve type consistency for Availability and Meeting documents. Part 1 of probably 2 or 3. The "{X}Actions" should now return the same types as the "{X}Managers"

Tested locally

Part of #124 